### PR TITLE
Add the ability to download things other than Pivotal tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A go library and cli executable to download a product from network.pivotal.io
 gopivnet -help
 Usage of gopivnet:
   -file="": filename where to save the pivotal product
+  -fileType="": type of file.  Defaults to 'pivotal' tile
   -product="": product to download
   -token="": pivnet token
   -version="": version of the product. If missing download the latest version

--- a/api/api.go
+++ b/api/api.go
@@ -44,7 +44,7 @@ func (p *PivnetApi) GetLatestProductFile(productName string, fileType string) (*
 
 	pivotalProduct := getPivotalProduct(productFiles, fileType)
 	if pivotalProduct == nil {
-		return nil, errors.New("Unable to fund a pivotal product")
+		return nil, errors.New("Unable to find a pivotal product")
 	}
 
 	return pivotalProduct, nil
@@ -86,7 +86,7 @@ func (p *PivnetApi) GetProductFileForVersion(productName, version string, fileTy
 
 	pivotalProduct := getPivotalProduct(productFiles, fileType)
 	if pivotalProduct == nil {
-		return nil, errors.New("Unable to fund a pivotal product")
+		return nil, errors.New("Unable to find a pivotal product")
 	}
 
 	return pivotalProduct, nil

--- a/api/api.go
+++ b/api/api.go
@@ -12,8 +12,8 @@ import (
 )
 
 type Api interface {
-	GetLatestProductFile(productName string) (*resource.ProductFile, error)
-	GetProductFileForVersion(productName, version string) (*resource.ProductFile, error)
+	GetLatestProductFile(productName string, fileType string) (*resource.ProductFile, error)
+	GetProductFileForVersion(productName, version string, fileType string) (*resource.ProductFile, error)
 	Download(productFile *resource.ProductFile, fileName string) error
 }
 
@@ -27,7 +27,7 @@ func New(token string) Api {
 	}
 }
 
-func (p *PivnetApi) GetLatestProductFile(productName string) (*resource.ProductFile, error) {
+func (p *PivnetApi) GetLatestProductFile(productName string, fileType string) (*resource.ProductFile, error) {
 	if productName == "" {
 		return nil, errors.New("Must specify a product name")
 	}
@@ -42,7 +42,7 @@ func (p *PivnetApi) GetLatestProductFile(productName string) (*resource.ProductF
 		return nil, err
 	}
 
-	pivotalProduct := getPivotalProduct(productFiles)
+	pivotalProduct := getPivotalProduct(productFiles, fileType)
 	if pivotalProduct == nil {
 		return nil, errors.New("Unable to fund a pivotal product")
 	}
@@ -50,9 +50,9 @@ func (p *PivnetApi) GetLatestProductFile(productName string) (*resource.ProductF
 	return pivotalProduct, nil
 }
 
-func getPivotalProduct(productFiles *resource.ProductFiles) *resource.ProductFile {
+func getPivotalProduct(productFiles *resource.ProductFiles, fileType string) *resource.ProductFile {
 	for index, productFile := range productFiles.Files {
-		if strings.Contains(productFile.AwsObjectKey, ".pivotal") {
+		if strings.Contains(productFile.AwsObjectKey, "." + fileType) {
 			return &productFiles.Files[index]
 		}
 	}
@@ -60,7 +60,7 @@ func getPivotalProduct(productFiles *resource.ProductFiles) *resource.ProductFil
 	return nil
 }
 
-func (p *PivnetApi) GetProductFileForVersion(productName, version string) (*resource.ProductFile, error) {
+func (p *PivnetApi) GetProductFileForVersion(productName, version string, fileType string) (*resource.ProductFile, error) {
 	if productName == "" {
 		return nil, errors.New("Must specify a product name")
 	}
@@ -84,7 +84,7 @@ func (p *PivnetApi) GetProductFileForVersion(productName, version string) (*reso
 		return nil, err
 	}
 
-	pivotalProduct := getPivotalProduct(productFiles)
+	pivotalProduct := getPivotalProduct(productFiles, fileType)
 	if pivotalProduct == nil {
 		return nil, errors.New("Unable to fund a pivotal product")
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -45,6 +45,10 @@ var _ = Describe("Api", func() {
 					Id:           22,
 					AwsObjectKey: "product.pivotal",
 				},
+                resource.ProductFile{
+                    Id:           23,
+                    AwsObjectKey: "cool.zip",
+                },
 			},
 		}
 
@@ -60,14 +64,14 @@ var _ = Describe("Api", func() {
 
 	Context("GetLatestProductFile", func() {
 		It("returns an error if there is no product name", func() {
-			res, err := api.GetLatestProductFile("")
+			res, err := api.GetLatestProductFile("", "pivotal")
 
 			Expect(res).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("fetches the right product", func() {
-			api.GetLatestProductFile("myprod")
+			api.GetLatestProductFile("myprod", "pivotal")
 
 			Expect(requester.GetProductCallCount()).To(Equal(1))
 			Expect(requester.GetProductArgsForCall(0)).To(Equal("myprod"))
@@ -75,14 +79,14 @@ var _ = Describe("Api", func() {
 
 		It("returns an error if fetching a product fails", func() {
 			requester.GetProductReturns(nil, errors.New("err"))
-			res, err := api.GetLatestProductFile("myprod")
+			res, err := api.GetLatestProductFile("myprod", "pivotal")
 
 			Expect(res).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("fetches the product files from the returned product", func() {
-			api.GetLatestProductFile("myprod")
+			api.GetLatestProductFile("myprod", "pivotal")
 
 			Expect(requester.GetProductFilesCallCount()).To(Equal(1))
 			Expect(requester.GetProductFilesArgsForCall(0)).To(Equal(prod.Releases[0]))
@@ -90,16 +94,23 @@ var _ = Describe("Api", func() {
 
 		It("returns an error if GetProductFiles fails", func() {
 			requester.GetProductFilesReturns(nil, errors.New("err"))
-			res, err := api.GetLatestProductFile("myprod")
+			res, err := api.GetLatestProductFile("myprod", "pivotal")
 
 			Expect(res).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("returns the latest product file", func() {
-			res, err := api.GetLatestProductFile("myprod")
+			res, err := api.GetLatestProductFile("myprod", "pivotal")
 
 			Expect(res).To(Equal(&productFiles.Files[1]))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+        It("returns the latest product file with an extension", func() {
+			res, err := api.GetLatestProductFile("myprod", "zip")
+
+			Expect(res).To(Equal(&productFiles.Files[2]))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -107,7 +118,7 @@ var _ = Describe("Api", func() {
 			productFiles.Files = productFiles.Files[:1]
 			requester.GetProductFilesReturns(productFiles, nil)
 
-			res, err := api.GetLatestProductFile("myprod")
+			res, err := api.GetLatestProductFile("myprod", "pivotal")
 
 			Expect(res).To(BeNil())
 			Expect(err).To(HaveOccurred())
@@ -116,21 +127,21 @@ var _ = Describe("Api", func() {
 
 	Context("GetProductFileForVersion", func() {
 		It("returns an error if there is no product name", func() {
-			res, err := api.GetProductFileForVersion("", "1.0")
+			res, err := api.GetProductFileForVersion("", "1.0", "pivotal")
 
 			Expect(res).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("returns an error if there is no product version", func() {
-			res, err := api.GetProductFileForVersion("name", "")
+			res, err := api.GetProductFileForVersion("name", "", "pivotal")
 
 			Expect(res).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("fetches the right product", func() {
-			api.GetProductFileForVersion("myprod", "1.0")
+			api.GetProductFileForVersion("myprod", "1.0", "pivotal")
 
 			Expect(requester.GetProductCallCount()).To(Equal(1))
 			Expect(requester.GetProductArgsForCall(0)).To(Equal("myprod"))
@@ -138,14 +149,14 @@ var _ = Describe("Api", func() {
 
 		It("returns an error if fetching a product fails", func() {
 			requester.GetProductReturns(nil, errors.New("err"))
-			res, err := api.GetProductFileForVersion("myprod", "1.0")
+			res, err := api.GetProductFileForVersion("myprod", "1.0", "pivotal")
 
 			Expect(res).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("fetches the product files from the returned product", func() {
-			api.GetProductFileForVersion("myprod", "1.0")
+			api.GetProductFileForVersion("myprod", "1.0", "pivotal")
 
 			Expect(requester.GetProductFilesCallCount()).To(Equal(1))
 			Expect(requester.GetProductFilesArgsForCall(0)).To(Equal(prod.Releases[1]))
@@ -153,16 +164,23 @@ var _ = Describe("Api", func() {
 
 		It("returns an error if GetProductFiles fails", func() {
 			requester.GetProductFilesReturns(nil, errors.New("err"))
-			res, err := api.GetProductFileForVersion("myprod", "1.0")
+			res, err := api.GetProductFileForVersion("myprod", "1.0", "pivotal")
 
 			Expect(res).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("returns the latest product file", func() {
-			res, err := api.GetProductFileForVersion("myprod", "1.0")
+			res, err := api.GetProductFileForVersion("myprod", "1.0", "pivotal")
 
 			Expect(res).To(Equal(&productFiles.Files[1]))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+        It("returns the latest product file", func() {
+			res, err := api.GetProductFileForVersion("myprod", "1.0", "zip")
+
+			Expect(res).To(Equal(&productFiles.Files[2]))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -170,7 +188,7 @@ var _ = Describe("Api", func() {
 			productFiles.Files = productFiles.Files[:1]
 			requester.GetProductFilesReturns(productFiles, nil)
 
-			res, err := api.GetProductFileForVersion("myprod", "1.0")
+			res, err := api.GetProductFileForVersion("myprod", "1.0", "pivotal")
 
 			Expect(res).To(BeNil())
 			Expect(err).To(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ var token = flag.String("token", "", "pivnet token")
 
 var file = flag.String("file", "", "filename where to save the pivotal product")
 
+var fileType = flag.String("fileType", "", "type of file.  Defaults to 'pivotal' tile.")
+
 func main() {
 	flag.Parse()
 
@@ -27,14 +29,18 @@ func main() {
 		log.Fatal("Need a pivnet token")
 	}
 
+    if *fileType == "" {
+        *fileType = "pivotal"
+    }
+
 	pivnetApi := api.New(*token)
 
 	var pivotalProduct *resource.ProductFile
 	var err error
 	if *version != "" {
-		pivotalProduct, err = pivnetApi.GetProductFileForVersion(*productName, *version)
+		pivotalProduct, err = pivnetApi.GetProductFileForVersion(*productName, *version, *fileType)
 	} else {
-		pivotalProduct, err = pivnetApi.GetLatestProductFile(*productName)
+		pivotalProduct, err = pivnetApi.GetLatestProductFile(*productName, *fileType)
 	}
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
At the moment, the utility seems to restrict you to only downloading Pivotal tiles (things that end with .pivotal).  This PR adds support to download other stuff by adding a `fileType` option to the utility.  The option defaults to `pivotal` so the behavior should be as it is now.  However you can change this to other values to get files of different types from PivNet.

This is useful for download stemcells, which end in '.tgz', buildpacks which end in '.zip' or Ops Manager images which have a variety of extensions.

I'm new to golang, so if my code is terrible let me know.  Happy to rework the PR a bit.
