### PR TITLE
Add support for getting the API token from an environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"./api"
+	"github.com/cfmobile/gopivnet/api"
 	"github.com/cfmobile/gopivnet/resource"
 )
 

--- a/main.go
+++ b/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
 
-	"github.com/cfmobile/gopivnet/api"
+	"./api"
 	"github.com/cfmobile/gopivnet/resource"
 )
 
@@ -26,7 +27,12 @@ func main() {
 	}
 
 	if *token == "" {
-		log.Fatal("Need a pivnet token")
+		var env = os.Getenv("PIVNET_TOKEN")
+		if env != "" {
+			token = &env
+		} else {
+			log.Fatal("Need a pivnet token")
+		}
 	}
 
 	if *fileType == "" {


### PR DESCRIPTION
I was looking for a quick way to get files from pivnet in a puppet manifest and stumbled across gopivnet.  One thing I wanted to do for my context was get the token from the environment, so I coded up a quick change to use the PIVNET_TOKEN environment variable for the token.
